### PR TITLE
rules: Disable the turbostat plugin on !amd64,!i386.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+collectd (5.5.0-2) unstable; urgency=low
+
+  * debian/rules:
+    - Disable the turbostat plugin on !amd64,!i386; it's Intel-hardware
+      specific.
+
+ -- Sebastian Harl <tokkee@debian.org>  Sun, 23 Aug 2015 15:35:26 +0200
+
 collectd (5.5.0-1) unstable; urgency=medium
 
   [ Marc Fournier ]

--- a/debian/rules
+++ b/debian/rules
@@ -144,6 +144,12 @@ ifneq (,$(filter kfreebsd-i386 kfreebsd-amd64, $(DEB_BUILD_ARCH)))
 		--disable-java
 endif
 
+# This plugin is Intel-hardware specific.
+ifeq (,$(filter amd64 i386, $(DEB_BUILD_ARCH)))
+	confflags += \
+		--disable-turbostat
+endif
+
 # The hppa buildds currently do not keep up with Java related stuff, thus
 # prevending testing transitions. sparc is also having trouble building the
 # java plugin.


### PR DESCRIPTION
It's Intel-hardware specific.
